### PR TITLE
Fix adding teachers to lessons

### DIFF
--- a/app/Models/LessonUser.php
+++ b/app/Models/LessonUser.php
@@ -32,5 +32,7 @@ class LessonUser extends Pivot
 
     protected $fillable = [
         'remind_at',
+        'participation',
+        'message',
     ];
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -137,16 +137,12 @@ class User extends Authenticatable
 
     public function hasSignedUpToCourse(Course $course): bool
     {
-        return $this->loadExists(['courses' => function (Builder $query) use ($course) {
-            $query->where('id', $course->id);
-        }])->courses_exists;
+        return $this->courses()->where('id', $course->id)->exists();
     }
 
     public function hasSignedInToLesson(Lesson $lesson): bool
     {
-        return $this->loadExists(['lessons' => function (Builder $query) use ($lesson) {
-            $query->where('id', $lesson->id);
-        }])->lessons_exists;
+        return $this->lessons()->where('id', $lesson->id)->exists();
     }
 
     public function accepts_mail_notifications(): bool


### PR DESCRIPTION
Due to the introduction of the pivot-model, the participation state needs to be set explicitely as a "fillable" entry. Otherwise the parameter in the attach function will be ignored and the default value of "signed-in" will be assigned.

Additionally, the functions
- hasSignedUpToCourse
- hasSignedInToLesson

have been simplified.