### PR TITLE
Add number of students to dashboard entries

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Enums\LessonParticipationEnum;
 use Carbon\Carbon;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
@@ -32,15 +33,20 @@ class DashboardController extends Controller
             ->with([
                 'course:id,name',
                 'teachers:id,first_name,last_name',
-            ])
+            ])->withCount(['participants' => function (Builder $query) {
+                $query->where('participation', LessonParticipationEnum::SIGNED_IN)
+                    ->orWhere('participation', LessonParticipationEnum::LATE);
+            }])
             ->where('start', '>', Carbon::now()->toDateString())
             ->oldest('start')->get();
 
         $teacherLessons = $user->teacherLessons()
             ->with([
                 'course:id,name',
-                'teachers:id,first_name,last_name',
-            ])
+            ])->withCount(['participants' => function (Builder $query) {
+                $query->where('participation', LessonParticipationEnum::SIGNED_IN)
+                    ->orWhere('participation', LessonParticipationEnum::LATE);
+            }])
             ->where('start', '>', Carbon::now()->subDays(3)->toDateString())
             ->oldest('start')->get();
 

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -212,10 +212,11 @@ if (isPushNotificationSupported()) {
                         hour: "2-digit",
                         minute: "2-digit",
                     }) }}</h3>
-                                <p class="pb-2">{{ lesson.title }} of {{ lesson.course.name }}</p>
+                                <p>{{ lesson.title }} of {{ lesson.course.name }}</p>
+                                <p>{{ lesson.participants_count }} students signed in.</p>
                             </div>
                             <Link :href="route('lessons.edit', [lesson.id])">
-                            <SecondaryButton class="mr-2">Edit Lesson</SecondaryButton>
+                            <SecondaryButton class="my-2 mr-2">Edit Lesson</SecondaryButton>
                             </Link>
                         </div>
                     </div>
@@ -241,15 +242,16 @@ if (isPushNotificationSupported()) {
                         hour: "2-digit",
                         minute: "2-digit",
                                     }) }}</h3>
-                                <p class="pb-2">{{ lesson.title }} of {{ lesson.course.name }}</p>
+                                <p>{{ lesson.title }} of {{ lesson.course.name }}</p>
                                 <p v-for="teacher in lesson.teachers" :key="teacher.id" class="italic">{{
                                     teacher.first_name
                                     }} {{ teacher.last_name }}</p>
+                                <p>{{ lesson.participants_count }} students signed in.</p>
                             </div>
-                            <DangerButton class="mr-2" v-if="lesson.pivot.participation == 'signed_in'"
+                            <DangerButton class="my-2 mr-2" v-if="lesson.pivot.participation == 'signed_in'"
                                 @click="signOut(lesson)">
                                 Sign Out</DangerButton>
-                            <SecondaryButton class="mr-2" v-else-if="lesson.pivot.participation == 'signed_out'"
+                            <SecondaryButton class="my-2 mr-2" v-else-if="lesson.pivot.participation == 'signed_out'"
                                 @click="signIn(lesson)">
                                 Sign In</SecondaryButton>
                             <SecondaryButton class="mr-2" @click="sendMessage(lesson)">Send Message</SecondaryButton>


### PR DESCRIPTION
Now, the number of signed in students is displayed on the dashboard.

With that everyone is able to see how full the lessons are going to be.